### PR TITLE
Move Bootstrap 4 to Maintenance LTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 | :--:     | :---:               | :---:           | :---:            | :---:                 | :---:                     |
 | [2.x][]  | **End-of-life**     | 2013-07-18      | -                | -                     | 2013-08-19                |
 | [3.x][]  | **End-of-life**     | 2013-08-19      | 2014-11-01       | 2016-09-05            | 2019-07-24                |
-| [4.x][]  | **Active LTS**      | 2018-01-18      | 2019-11-26       | 2020-05-26            | 2020-11-26                |
-| 5.x      | **Active**          | TBD             | TBD              | TBD                   | TBD                       |
+| [4.x][]  | **Maintenance LTS**      | 2018-01-18      | 2019-11-26       | 2020-05-26            | 2020-11-26                |
+| 5.x      | **Not Yet Released**          | TBD             | TBD              | TBD                   | TBD                       |
 
 **Warning:** Dates may vary widely. We are actively working on strengthening timeline assurances.
 


### PR DESCRIPTION
The 5/26/2020 date has already passed. This patch fixes the table, moving v4 to Maintenance LTS.

Also, I statd that v5 has not yet been released.