### PR TITLE
Add active LTS start date for 5.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 | [2.x][] | **End-of-life** | 2013-07-18      | -                | -                     | 2013-08-19  |
 | [3.x][] | **End-of-life** | 2013-08-19      | 2014-11-01       | 2016-09-05            | 2019-07-24  |
 | [4.x][] | **End-of-life** | 2018-01-18      | 2019-11-26       | 2021-11-01            | 2023-01-01  |
-| [5.x][] | **Active LTS**  | 2021-05-05      | TBD              | TBD                   | TBD         |
+| [5.x][] | **Active LTS**  | 2021-05-05      | 2022-07-19       | TBD                   | TBD         |
 
 **Warning:** Dates may vary widely. We are actively working on strengthening timeline assurances.
 


### PR DESCRIPTION
This PR suggests modifying our README to add a start date for 5.X active LTS start.
EOL 4.X date is 2023-01-01 and the latest 4.X version (4.6.2) was released the 2022-07-19.
I've chosen the same date which corresponds to our 5.2.0 release date.

IDK what was the logic of the choice of active LTS start date, feel free to modify the date or close directly the PR.


